### PR TITLE
Add day/week/month to leaderboard query

### DIFF
--- a/history/package.json
+++ b/history/package.json
@@ -7,6 +7,7 @@
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/faker": "^5.5.9",
+    "@types/http-status-codes": "^1.2.0",
     "@types/jest": "^27.0.2",
     "@types/morgan": "^1.9.3",
     "@types/node": "^16.11.6",

--- a/history/src/controllers/leaderboardController.ts
+++ b/history/src/controllers/leaderboardController.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 
 import leaderboardService from 'services/LeaderboardService';
 import { ErrorResponse } from 'types/api';
-import { LeaderboardData } from 'types/crud/leaderboard';
+import { LeaderboardApiResponse } from 'types/api/leaderboard';
 import { AuthorizationError } from 'types/error';
 
 /**
@@ -14,12 +14,23 @@ import { AuthorizationError } from 'types/error';
  */
 export async function readLeaderboard(
   _request: Request<unknown, unknown, unknown>,
-  response: Response<ErrorResponse | LeaderboardData[]>,
+  response: Response<ErrorResponse | LeaderboardApiResponse>,
 ): Promise<void> {
   const { user } = response.locals;
   try {
-    const leaderboardData = await leaderboardService.read(user);
-    response.status(StatusCodes.OK).json(leaderboardData);
+    const day = await leaderboardService.read(user);
+    const week = await leaderboardService.read(
+      user,
+      10,
+      new Date(new Date().setDate(new Date().getDate() - 7)),
+    );
+    const month = await leaderboardService.read(
+      user,
+      10,
+      // We'll just use 30 days for month query
+      new Date(new Date().setDate(new Date().getDate() - 30)),
+    );
+    response.status(StatusCodes.OK).json({ day, week, month });
   } catch (error: any) {
     if (error instanceof AuthorizationError) {
       response.status(StatusCodes.FORBIDDEN).json({

--- a/history/src/routes/__tests__/leaderboard.spec.ts
+++ b/history/src/routes/__tests__/leaderboard.spec.ts
@@ -28,14 +28,24 @@ describe('GET /leaderboard', () => {
     rankedUsers = await fixtures.generateLeaderboardUsers();
   });
 
-  it('should return the top 10 users', async () => {
+  it('should return the same top 10 users for day, week and month', async () => {
     const response = await request(server.server)
       .get('/leaderboard')
       .set('Authorization', fixtures.userOne.id)
       .send();
     expect(response.status).toBe(StatusCodes.OK);
-    expect(response.body).toHaveLength(10);
-    expect(response.body).toEqual(convertDatesToJson(rankedUsers.slice(0, 10)));
+    expect(response.body.day).toHaveLength(10);
+    expect(response.body.day).toEqual(
+      convertDatesToJson(rankedUsers.slice(0, 10)),
+    );
+    expect(response.body.week).toHaveLength(10);
+    expect(response.body.week).toEqual(
+      convertDatesToJson(rankedUsers.slice(0, 10)),
+    );
+    expect(response.body.month).toHaveLength(10);
+    expect(response.body.month).toEqual(
+      convertDatesToJson(rankedUsers.slice(0, 10)),
+    );
   });
 
   it('should not allow invalid uid', async () => {

--- a/history/src/services/LeaderboardService.ts
+++ b/history/src/services/LeaderboardService.ts
@@ -12,13 +12,17 @@ class LeaderboardService extends BaseService<LeaderboardData[], void> {
     new AlwaysAllowPolicy(),
   ];
 
-  async read(user: User, top = 10): Promise<LeaderboardData[]> {
+  async read(
+    user: User,
+    top = 10,
+    before = new Date(new Date().setDate(new Date().getDate() - 1)),
+  ): Promise<LeaderboardData[]> {
     const users = await prisma.$queryRaw<LeaderboardData[]>`
     SELECT
       u.*,
-      (SELECT COUNT(*) FROM "public"."MeetingRecord" m WHERE m."intervieweeId" = u.id AND m."questionDifficulty" = 'EASY') AS "numEasyQuestions",
-      (SELECT COUNT(*) FROM "public"."MeetingRecord" m WHERE m."intervieweeId" = u.id AND m."questionDifficulty" = 'MEDIUM') AS "numMediumQuestions",
-      (SELECT COUNT(*) FROM "public"."MeetingRecord" m WHERE m."intervieweeId" = u.id AND m."questionDifficulty" = 'HARD') AS "numHardQuestions"
+      (SELECT COUNT(*) FROM "public"."MeetingRecord" m WHERE m."createdAt" > ${before} AND m."intervieweeId" = u.id AND m."questionDifficulty" = 'EASY') AS "numEasyQuestions",
+      (SELECT COUNT(*) FROM "public"."MeetingRecord" m WHERE m."createdAt" > ${before} AND m."intervieweeId" = u.id AND m."questionDifficulty" = 'MEDIUM') AS "numMediumQuestions",
+      (SELECT COUNT(*) FROM "public"."MeetingRecord" m WHERE m."createdAt" > ${before} AND m."intervieweeId" = u.id AND m."questionDifficulty" = 'HARD') AS "numHardQuestions"
     FROM
       "public"."User" u
     ORDER BY

--- a/history/src/types/api/leaderboard.ts
+++ b/history/src/types/api/leaderboard.ts
@@ -1,0 +1,7 @@
+import { LeaderboardData } from '../crud/leaderboard';
+
+export interface LeaderboardApiResponse {
+  day: LeaderboardData[];
+  week: LeaderboardData[];
+  month: LeaderboardData[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2846,6 +2846,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/http-status-codes@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/http-status-codes/-/http-status-codes-1.2.0.tgz#6e5244835aaf7164dd306f1d4d2dfdbb2159d909"
+  integrity sha512-vjpjevMaxtrtdrrV/TQNIFT7mKL8nvIKG7G/LjMDZdVvqRxRg5SNfGkeuSaowVc0rbK8xDA2d/Etunyb5GyzzA==
+  dependencies:
+    http-status-codes "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -8102,7 +8109,7 @@ http-proxy@^1.17.0, http-proxy@^1.18.1:
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
-http-status-codes@^2.1.4:
+http-status-codes@*, http-status-codes@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-2.1.4.tgz#453d99b4bd9424254c4f6a9a3a03715923052798"
   integrity sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg==


### PR DESCRIPTION
### Summary

To support the UI of having a leaderboard for day, week and month, a `before` parameter was added to the leaderboard query.

Future:

- Cache the queries using redis.

### Test Plan

Added tests. Unfortunately, I'm unable to test whether the cutoff works.

```
cd history && yarn test
```